### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ subdirectories. The source code of all required GraphSense components is
 included through Git submodules. To fetch the source code for all components use
 
 ```
-git clone git@github.com:graphsense/graphsense-setup.git
+git clone https://github.com/graphsense/graphsense-setup.git .
 git submodule init
 git submodule update
 ```


### PR DESCRIPTION
Cloning with ssh is not possible without adding an SSH key. So for the general public it is better when you add cloning with HTTPS. Furthermore you need to either add a "dot" at the end of the clone command or then add "cd graphsense-setup" as a second command to your example.